### PR TITLE
configure mailtrap.io with default email settings

### DIFF
--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Appointment;
 use App\Interfaces\AppointmentInterface;
 use Illuminate\Http\Request;
-use Swift_SmtpTransport;
-use Swift_Mailer;
-use Swift_Message;
+// use Swift_SmtpTransport;
+// use Swift_Mailer;
+// use Swift_Message;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\CreateAppointment;
 
 class AppointmentController extends Controller
 {
@@ -36,7 +39,7 @@ class AppointmentController extends Controller
         $newAppt = $this->appointment->create($params);
 
         // send email
-        $this->sendEmail();
+        $this->sendEmail($newAppt);
 
         return $newAppt;
     }
@@ -63,24 +66,8 @@ class AppointmentController extends Controller
         return $appt;
     }
 
-    private function sendEmail()
+    private function sendEmail(Appointment $appointmentDetails)
     {
-        // Create the Transport
-        $transport = (new Swift_SmtpTransport(env('MAIL_HOST'), env('MAIL_PORT')))
-        ->setUsername(env('MAIL_USERNAME'))
-        ->setPassword(env('MAIL_PASSWORD'))
-        ;
-
-        $mailer = new Swift_Mailer($transport);
-
-        // Create a message
-        $message = (new Swift_Message('AYYYYY YO'))
-        ->setFrom(['appointment@tthompson899.com' => 'Tiffany'])
-        ->setTo(['email@example.com'])
-        ->setBody('Here is the message itself')
-        ;
-
-        // Send the message
-        $result = $mailer->send($message);
+        Mail::to($appointmentDetails->user->email)->send(new CreateAppointment());
     }
 }

--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Interfaces\AppointmentInterface;
 use Illuminate\Http\Request;
+use Swift_SmtpTransport;
+use Swift_Mailer;
+use Swift_Message;
 
 class AppointmentController extends Controller
 {
@@ -32,6 +35,9 @@ class AppointmentController extends Controller
 
         $newAppt = $this->appointment->create($params);
 
+        // send email
+        $this->sendEmail();
+
         return $newAppt;
     }
 
@@ -55,5 +61,26 @@ class AppointmentController extends Controller
         $appt = $this->appointment->delete($id);
 
         return $appt;
+    }
+
+    private function sendEmail()
+    {
+        // Create the Transport
+        $transport = (new Swift_SmtpTransport(env('MAIL_HOST'), env('MAIL_PORT')))
+        ->setUsername(env('MAIL_USERNAME'))
+        ->setPassword(env('MAIL_PASSWORD'))
+        ;
+
+        $mailer = new Swift_Mailer($transport);
+
+        // Create a message
+        $message = (new Swift_Message('AYYYYY YO'))
+        ->setFrom(['appointment@tthompson899.com' => 'Tiffany'])
+        ->setTo(['email@example.com'])
+        ->setBody('Here is the message itself')
+        ;
+
+        // Send the message
+        $result = $mailer->send($message);
     }
 }

--- a/app/Mail/CreateAppointment.php
+++ b/app/Mail/CreateAppointment.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class CreateAppointment extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from('appointments@dentist.com', 'Dentist')
+                    ->view('emails.create-appointment');
+    }
+}

--- a/app/Mail/CreateAppointment.php
+++ b/app/Mail/CreateAppointment.php
@@ -29,6 +29,7 @@ class CreateAppointment extends Mailable
     public function build()
     {
         return $this->from('appointments@dentist.com', 'Dentist')
+                    ->subject('New Appointment')
                     ->view('emails.create-appointment');
     }
 }

--- a/app/Repositories/AppointmentRepository.php
+++ b/app/Repositories/AppointmentRepository.php
@@ -56,7 +56,7 @@ class AppointmentRepository implements AppointmentInterface
             'type_id' => $type->id
         ]);
 
-        return response()->json($appt);
+        return $appt;
     }
 
     public function update($id, $params)

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
         "php": "^7.2.5||^8.0",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.3",
         "laravel/framework": "^7.0",
-        "laravel/tinker": "^2.0"
+        "laravel/tinker": "^2.0",
+        "swiftmailer/swiftmailer": "^6.0"
     },
     "require-dev": {
         "facade/ignition": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90904f8c7680122032ddf636a4b35700",
+    "content-hash": "bcbb717742f8b8c5a00ba145480466ba",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -566,37 +566,44 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.5",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e"
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
-                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.17.0"
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
                 "psr/log": "^1.1"
             },
             "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5-dev"
+                    "dev-master": "7.3-dev"
                 }
             },
             "autoload": {
@@ -616,6 +623,11 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
@@ -626,14 +638,34 @@
                 "framework",
                 "http",
                 "http client",
+                "psr-18",
+                "psr-7",
                 "rest",
                 "web service"
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5"
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
             },
-            "time": "2020-06-16T21:01:06+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1723,6 +1755,58 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-message",

--- a/resources/views/emails/create-appointment.blade.php
+++ b/resources/views/emails/create-appointment.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.default')
+@section('content')
+<div class="container">
+  <div class="card my-5">
+    <div class="card-body">
+      <h1>You have a new appointment!</h1>
+      <h5 class="text-muted mb-2">Check out your appointment details below.</h5>
+      <!-- link to appointment -->
+      <!-- <a class="btn btn-primary" href="#">Click Me</a> -->
+
+      <!-- name, appt date and time -->
+    </div>
+  </div>
+</div>
+@stop

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Your Next Appointment</title>
+</head>
+<body>
+<div class="container">
+    <div id="main" class="row">
+        @yield('content')
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Issues during this PR:
- Error with email not being sent to mailtrap 
    - I copied the settings over from https://swiftmailer.symfony.com/docs/introduction.html but forgot to change the port to the one I added in my .env file
    - Original error message:
    - `Swift_TransportException: Connection could not be established with host smtp.mailtrap.io :stream_socket_client(): Unable to connect to smtp.mailtrap.io:25`
          - Port was incorrect
